### PR TITLE
beryllium: update build fingerprint from MIUI 11.0.8.0

### DIFF
--- a/lineage_beryllium.mk
+++ b/lineage_beryllium.mk
@@ -16,10 +16,10 @@ PRODUCT_BRAND := Xiaomi
 PRODUCT_MODEL := POCO F1
 PRODUCT_MANUFACTURER := Xiaomi
 
-BUILD_FINGERPRINT := "Xiaomi/beryllium/beryllium:10/QKQ1.190828.002/V11.0.6.0.QEJMIXM:user/release-keys"
+BUILD_FINGERPRINT := "Xiaomi/beryllium/beryllium:10/QKQ1.190828.002/V11.0.8.0.QEJMIXM:user/release-keys"
 
 PRODUCT_BUILD_PROP_OVERRIDES += \
-    PRIVATE_BUILD_DESC="beryllium-user 10 QKQ1.190828.002 V11.0.6.0.QEJMIXM release-keys" \
+    PRIVATE_BUILD_DESC="beryllium-user 10 QKQ1.190828.002 V11.0.8.0.QEJMIXM release-keys" \
     PRODUCT_NAME="beryllium"
 
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi-rev1

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1,4 +1,4 @@
-# Device proprietary files - from beryllium's MIUI package V11.0.6.0.QEJMIXM global stable version
+# Device proprietary files - from beryllium's MIUI package V11.0.8.0.QEJMIXM global stable version
 
 # ACDB
 vendor/etc/acdbdata/Forte/Forte_Bluetooth_cal.acdb


### PR DESCRIPTION
Hi, I currently have the problem of a SafetyNet CTS mismatch, preventing me from using my banking app. I'm running on MIUI 11.0.8.0 and LOS 17.1-20200529-NIGHTLY-beryllium. I investigated a bit and read that it could be caused by an outdated firmware fingerprint.

I thought it can't hurt to try updating it to the latest stable and hope this PR (inspired by https://github.com/LineageOS/android_device_xiaomi_beryllium/pull/2 and https://github.com/crdroidandroid/android_device_xiaomi_beryllium/commit/110348a812a6261e3dc2c5c1b720b66ae4f5f9ca) fixes the problem.